### PR TITLE
psAgeModel NaNs issue

### DIFF
--- a/psAgeModel.m
+++ b/psAgeModel.m
@@ -83,7 +83,7 @@ function [ts, criticalPts] = psAgeModel(y, varargin)
     %% Initialize input
     
     % remove NaNs
-    y = y(~isnan(y));
+    y = fillmissing(y,'linear');
     
     % set y to a column vector
     if isrow(y)


### PR DESCRIPTION
fix for issue #1
critical point indices didn't match the original input vector indices because of the way that NaNs were removed. To fix this NaNs are infilled using linear interpolation instead